### PR TITLE
Use 0.0.23 version explicitly for unpkg smartdown. Remove unnecessary inclusion of plotly, which is already included via Smartdown.

### DIFF
--- a/demo.md
+++ b/demo.md
@@ -22,12 +22,7 @@ Use the navigation buttons below to explore different aspects of Smartdown.
 - [Cells](:@Cells)
 - [Plotly](:@Plotly)
 - [P5](:@P5)
-
-### GIF Example
-
-I'm experimenting with incorporating GIFs for the purpose of building a tutorial.
-
-![player](https://unpkg.com/smartdown/docs/lib/example/intro.gif)
+- [Tweet](:@Tweet)
 
 
 # SVG
@@ -492,6 +487,22 @@ p5.draw = function () {
 
 ```
 
+
+---
+
+[Back to Home](:@Home)
+
+
+
+# Tweet
+---
+
+### Tweet Example
+
+Testing out lazy loading of Twitter library.
+
+- [](https://twitter.com/mrdatascience/status/857681153872072705&showMedia)
+- [](https://twitter.com/mrdatascience/status/858010008017154049&showMedia)
 
 ---
 

--- a/smartdown_template.html
+++ b/smartdown_template.html
@@ -13,11 +13,10 @@
 
   <!-- link rel="shortcut icon" href="favicon.ico" / -->
   <!-- Use Bootstrap CSS for this page's look -->
-  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-  <link rel=stylesheet href="https://unpkg.com/smartdown/docs/lib/smartdown.css">
-  <script src="https://unpkg.com/smartdown/docs/lib/smartdown.js"></script>
+  <link rel=stylesheet href="https://unpkg.com/smartdown@0.0.23/docs/lib/smartdown.css">
+  <script src="https://unpkg.com/smartdown@0.0.23/docs/lib/smartdown.js"></script>
 
   <script type="text/x-smartdown" id="SmartdownPreview">$content</script>
 </head>
@@ -31,7 +30,7 @@
 
   <script>
   /* global smartdown */
-  var baseURL = 'https://unpkg.com/smartdown/docs/';
+  var baseURL = 'https://unpkg.com/smartdown@0.0.23/docs/';
   var icons = {
     'hypercube': baseURL + 'lib/example/Hypercube.svg',
     'StalactiteStalagmite': baseURL + 'lib/example/StalactiteStalagmite.svg'


### PR DESCRIPTION
- Use 0.0.23 version explicitly for unpkg smartdown.
- Remove unnecessary inclusion of plotly, which is already included via Smartdown.