### PR TITLE
Debug mode, no more unpkg.com, Unicode, autoplay, multipart.

### DIFF
--- a/smartdown_template.html
+++ b/smartdown_template.html
@@ -7,18 +7,18 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
 
-  <base href="http://smartdown.site/">
+  <base href="${smartdownSiteURL}">
 
-  <title>$title</title>
+  <title>${title}</title>
 
   <!-- link rel="shortcut icon" href="favicon.ico" / -->
   <!-- Use Bootstrap CSS for this page's look -->
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-  <link rel=stylesheet href="https://unpkg.com/smartdown@0.0.24/docs/lib/smartdown.css">
-  <script src="https://unpkg.com/smartdown@0.0.24/docs/lib/smartdown.js"></script>
+  <link rel=stylesheet href="${smartdownModulePrefix}smartdown.css">
+  <script src="${smartdownModulePrefix}smartdown.js"></script>
 
-  <script type="text/x-smartdown" id="SmartdownPreview">$content</script>
+  <script type="text/x-smartdown" id="SmartdownPreview">${content}</script>
 </head>
 
 <body style="margin:0;padding:0;background:#FEFEFE;">
@@ -30,7 +30,7 @@
 
   <script>
   /* global smartdown */
-  var baseURL = 'https://unpkg.com/smartdown@0.0.24/docs/';
+  var baseURL = 'https://smartdown.site/';
   var icons = {
     'hypercube': baseURL + 'lib/example/Hypercube.svg',
     'StalactiteStalagmite': baseURL + 'lib/example/StalactiteStalagmite.svg'
@@ -43,6 +43,7 @@
     multiparts = smartdown.partitionMultipart(sourceText);
     var output = document.getElementById('smartdown-output');
     smartdown.setHome(multiparts._default_, output, function() {
+      smartdown.startAutoplay(output);
     });
   }
   function loadURL(url) {
@@ -57,6 +58,7 @@
     multiparts = smartdown.partitionMultipart(s.text);
     var output = document.getElementById('smartdown-output');
     smartdown.setHome(multiparts._default_, output, function() {
+      smartdown.startAutoplay(output);
     });
   }
   function loadExample() {

--- a/smartdownpreview.py
+++ b/smartdownpreview.py
@@ -8,6 +8,16 @@ import webbrowser
 import base64
 import os
 import pdb
+from string import Template
+
+useLocal = False
+
+if useLocal:
+	smartdownSiteURL = 'http://127.0.0.1:8080/lib/'
+	smartdownModulePrefix = smartdownSiteURL
+else:
+	smartdownSiteURL = 'https://smartdown.site/'
+	smartdownModulePrefix = 'https://smartdown.site/lib/'
 
 class SmartdownpreviewCommand(sublime_plugin.TextCommand):  #sublime_plugin.EventListener):
 
@@ -26,12 +36,16 @@ class SmartdownpreviewCommand(sublime_plugin.TextCommand):  #sublime_plugin.Even
 			#full_url = self.generate_url()
 			#preview = self.openUrl(full_url)
 			currentFileName = os.path.basename(self.currentFilePath)
-			content = open(self.currentFilePath, "r").read()
+			content = open(self.currentFilePath, "r", encoding='utf-8').read()
 			self.previewFilePath = os.path.join(os.path.expanduser("~"), 'tmp')
 			if not os.path.exists(self.previewFilePath):
 				os.mkdir(self.previewFilePath)
 			previewFileFullPath = os.path.join(self.previewFilePath, "{}.html".format(currentFileName))
-			html_string = self.generate_html(title=currentFileName, content=content)
+			html_string = self.generate_html(
+									title=currentFileName,
+									content=content,
+									smartdownSiteURL=smartdownSiteURL,
+									smartdownModulePrefix=smartdownModulePrefix)
 			self.save_tmp_file(html_string, outFilePath=previewFileFullPath)
 			full_url = 'file://' + previewFileFullPath
 			self.openUrl(full_url)
@@ -40,19 +54,27 @@ class SmartdownpreviewCommand(sublime_plugin.TextCommand):  #sublime_plugin.Even
 			self.log('This file is not SmartDown format!')
 			pass
 
-	def generate_html(self, title, content):
+	def generate_html(self, title, content, smartdownSiteURL, smartdownModulePrefix):
 		'''
 		Generates an html file from template and current file content, saves it locally.
 		'''
 		html_template = open(self.html_template, "r").read()
+		preview_html = Template(html_template).substitute(
+							title=title,
+							content=content,
+							smartdownSiteURL=smartdownSiteURL,
+							smartdownModulePrefix=smartdownModulePrefix)
+
 		#pdb.set_trace()
 		# Replace title and content in template with actual file we're editing
-		preview_html = html_template.replace('$title', title)
-		preview_html = preview_html.replace('$content', content)
+		# preview_html = html_template.replace('$title', title)
+		# preview_html = preview_html.replace('$content', content)
+		# preview_html = preview_html.replace('$smartdownSiteURL', smartdownSiteURL)
+		# preview_html = preview_html.replace('$smartdownModulePrefix', smartdownModulePrefix)
 		return preview_html
 
 	def save_tmp_file(self, string, outFilePath):
-		with open(outFilePath, 'w') as outFile:
+		with open(outFilePath, 'w', encoding='utf-8') as outFile:
 			outFile.write(string)
 
 


### PR DESCRIPTION
- Enable debugging via local Smartdown server.
- Replace use of unpkg.com with newly CloudFlared smartdown.site (https).
- Fixed issues with previewing files containing Unicode characters.
- Fixed autoplay and multipart issues.
- Use Python string Templates.
